### PR TITLE
Chore: Remove deprecated fields from Market Status Schema table

### DIFF
--- a/src/3.x/endpoints/market-status.md
+++ b/src/3.x/endpoints/market-status.md
@@ -36,13 +36,10 @@ Attribution to TradingHours.com, including a clearly visible link, is required w
 ### Schema
 | Field | Format | Description |
 | ------------- | ------------- | --------- |
-| local-time | ISO 8601 | The current local time at the market. <span style="color: red"><b>(Deprecated)</b></span> |
 | status | String | `Open` if it is currently a primary trading session. `Closed` otherwise, including for pre- and post-trading sessions. |
 | reason | String | Explanation of the current response, including phase(s), holidays, and irregular schedules. |
 | until | ISO 8601 | Displays the end of the current phase. |
 | next_bell | ISO 8601 | Displays the time when the market opens or closes next. |
-| utc_time | ISO 8601 | Displays the time in UTC. <span style="color: red"><b>(Deprecated)</b></span> |
-| time | ISO 8601 | Displays the same as "utc_time". <span style="color: red"><b>(Deprecated)</b></span> |
 | timezone | String | Timezone of this trading venue (Olson timezone format) |
 
 


### PR DESCRIPTION
## Description
Removed the deprecated fields from the Schema table in the [Market Status](https://docs.tradinghours.com/3.x/endpoints/market-status) page. 